### PR TITLE
Vérification du retour de la fonction sem_post

### DIFF
--- a/exemplier/5_synchronization/semaphores/posix_semaphore.c
+++ b/exemplier/5_synchronization/semaphores/posix_semaphore.c
@@ -123,7 +123,7 @@ void V(semaphore_t *sem)
 {
     int r = 0;
 
-    sem_post(sem);
+    r = sem_post(sem);
     if (r < 0) {
         handle_fatal_error("Error [V()]: ");
     }


### PR DESCRIPTION
Dans la fonction V de posix_semaphore.c, le retour de la fonction sem_post n'était pas réupéré.